### PR TITLE
fix: move item reversal from timeline to GraphQL query

### DIFF
--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -29,7 +29,7 @@ const Timeline: React.FC<TimelinePayload> = ({data}) => {
 					whileInView={{ opacity: 1, scale: 1 }}
 					viewport={{ once: true }}
 					transition={{ duration: 0.7, type: 'spring', delay: 0.3 }} className="grid grid-cols-2">
-					{data.reverse().map((element, index) => {
+					{data.map((element, index) => {
 						if (index % 2 == 0) return (
 							<React.Fragment key={element.abbr}>
 								<div className="flex justify-center items-center relative pl-12" key={element.abbr}>

--- a/util/queries/frontPage.ts
+++ b/util/queries/frontPage.ts
@@ -1,63 +1,63 @@
-import { gql } from 'graphql-request'
+import { gql } from "graphql-request";
 
 export const FRONT_PAGE_QUERY = gql`
-	query FrontPage {
-		frontPage(where: {id: "clfr1a4pm4uep0bw7woyr226e"}) {
-			aboutMe {
-				title
-				footer {
-					html
-				}
-				content {
-					text
-				}
-			}
-			academic {
-				abbr
-				daterange
-				desc
-				title
-				displayDateWithMonths
-			}
-			mainSectionImages {
-				url
-				mimeType
-			}
-			projectSection {
-				title
-				featuredText
-				buttonText
-				project {
-					desc
-					date
-					image {
-						url
-					}
-					title
-					technologies
-					github
-					content {
-						html
-					}
-				}
-			}
-			workExperience {
-				title
-				desc
-				daterange
-				abbr
-				displayDateWithMonths
-			}
-			skills {
-				logos(first: 12) {
-					url(transformation: {document: {output: {format: webp}}})
-				}
-				title
-				categories {
-					technologies
-					name
-				}
-			}
-		}
-	}
-`
+  query FrontPage {
+    frontPage(where: { id: "clfr1a4pm4uep0bw7woyr226e" }) {
+      aboutMe {
+        title
+        footer {
+          html
+        }
+        content {
+          text
+        }
+      }
+      academic {
+        abbr
+        daterange
+        desc
+        title
+        displayDateWithMonths
+      }
+      mainSectionImages {
+        url
+        mimeType
+      }
+      projectSection {
+        title
+        featuredText
+        buttonText
+        project {
+          desc
+          date
+          image {
+            url
+          }
+          title
+          technologies
+          github
+          content {
+            html
+          }
+        }
+      }
+      workExperience(orderBy: daterange_DESC) {
+        title
+        desc
+        daterange
+        abbr
+        displayDateWithMonths
+      }
+      skills {
+        logos(first: 12) {
+          url(transformation: { document: { output: { format: webp } } })
+        }
+        title
+        categories {
+          technologies
+          name
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
item reversal on the client side didn't work as expected once deployed due to build settings, and broke item selection - decided to order by date desc in graphql query